### PR TITLE
Create eid-federation-api.yaml

### DIFF
--- a/external-apis/eid-federation-api.yaml
+++ b/external-apis/eid-federation-api.yaml
@@ -1,0 +1,444 @@
+x-commons:
+  ratelimit-headers:
+    X-RateLimit-Limit:
+      $ref: '#/components/headers/X-RateLimit-Limit'
+    X-RateLimit-Remaining:
+      $ref: '#/components/headers/X-RateLimit-Remaining'
+    X-RateLimit-Reset:
+      $ref: '#/components/headers/X-RateLimit-Reset'
+  common-responses:
+    '400':
+      $ref: '#/components/responses/400BadRequest'
+    '401':
+      $ref: '#/components/responses/401Unauthorized'
+    '429':
+      $ref: '#/components/responses/429TooManyRequests'
+    '500':
+      $ref: '#/components/responses/500InternalServerError'
+    '503':
+      $ref: '#/components/responses/503ServiceUnavailable'
+    default:
+      $ref: '#/components/responses/default'
+openapi: 3.0.2
+info:
+  version: 0.2.0
+  title: eID Registry
+  x-summary: API della Infrastruttura delle Identità Digitali Nazionale
+  description: |-
+    #### Documentazione
+    L'API permette di recuperare i dati relativi relativi alle entità di identità digitale. Per maggiori informazioni visitare la pagina https://#. **API in versione beta.**
+  termsOfService: 'https://#/terms'
+  contact:
+    email: servicedesk@example.it
+    name: eID Registry service Desk
+    url: 'https://apistore.example.it/home'
+  x-audience:
+    - public
+  x-api-id: 5da400c9-8652-4470-ad14-7613506ccdf7
+tags:
+  - name: Certificate
+    description: Certificato utilizzato dalla Autorità di Federazione per le operazioni di firma digitale
+  - name: SAML2 MetaData Query
+    description: api per recuperare metadata di tipo SAML2
+  - name: OIDC Federation
+    description: api per recuperare metadata di tipo OIDC
+  - name: Stato
+    description: Stato dell'API
+servers:
+  - url: 'https://api.example.it/eid/0.2.0'
+    description: produzione
+  
+paths:
+  /certificate:
+   get:
+      summary: Certificato della Autorità di Federazione
+      description: Permette di recuperare il certificato utilizzato nelle operazioni di firma per la validazione delle responses
+      operationId: certificate
+      tags:
+        - Certificate
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      responses:
+        '200':
+          description: Federation Authority x509 Certificate in PEM or DER format
+          content:
+            application/x-pem-file:
+              schema:
+                type: string
+            application/x-x509-ca-cert:
+              schema:
+                type: string
+            application/jwk+json:
+              schema:
+                type: string
+  /entities:
+    get:
+      summary: Metadata aggregato di Federazione SAML2
+      description: Permette di recuperare il metadata SAML2 aggregato e firmato
+      operationId: entities
+      tags:
+        - SAML2 MetaData Query
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      responses:
+        '200':
+          description: SAML2 Metadata
+          content:
+            samlmetadata/xml:
+              schema:
+                type: object # definire lo schema SAML2 metadata
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+  /entities/{entityid}:
+    get:
+      summary: Metadata di una singola entità SAML2
+      description: Permette di recuperare il metadata SAML2 firmato di una specifica Entità
+      operationId: entity
+      tags:
+        - SAML2 MetaData Query
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      parameters:
+      - name: "entityid"
+        in: "path"
+        description: "entityid SAML2 Metadata"
+        required: true
+        schema:
+          type: string # definire qui i dettagli per {sha1} e urlencoded format
+      responses:
+        '200':
+          description: SAML2 Metadata
+          content:
+            samlmetadata/xml:
+              schema:
+                type: object # definire lo schema SAML2 metadata
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+  /.well-known/openid-federation:
+    get:
+      summary: Federation Entity Configuration
+      description: |
+        Response example: <a href="https://openid.net/specs/openid-connect-federation-1_0.html#rfc.section.5.2">OIDC Federation 1.0 #5.2</a>
+      operationId: openid-federation
+      tags:
+        - OIDC Federation
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      responses:
+        '200':
+          description: SAML2 Metadata
+          content:
+            application/jwt:
+              schema:
+                type: object # definire lo schema
+            application/jose:
+              schema:
+                type: object # definire lo schema
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+  /federation_api:
+    get:
+      summary: Fetch a single entity or a list of entity
+      description: |
+        L'API della federazione è un'API HTTPS che può supportare più operazioni. Il recupero delle entità è una delle operazioni e l'unica da supportare. Tutte le altre operazioni sono OPZIONALI. L'elenco delle operazioni definite potrebbe essere ampliato in futuro.
+        
+        Esempio di response: <a href="https://openid.net/specs/openid-connect-federation-1_0.html#rfc.section.6.1.2">OIDC Federation 1.0 #6.1.2</a>
+      operationId: federation_api
+      tags:
+        - OIDC Federation
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      parameters:
+      - name: "operation"
+        in: "query"
+        description: OPTIONAL. If not present, MUST be treated as 'fetch'. Otherwise it could be 'listing'
+        required: false
+        schema:
+          type: string
+      - name: "iss"
+        in: "query"
+        description: |
+          REQUIRED. The entity identifier of the issuer from which you want an entity statement issued. Because of the normalization of the URL, multiple issuers may resolve to a shared federation API. This parameter makes it explicit exactly which issuer we want entity statements from.
+        required: true
+        schema:
+          type: string
+      - name: "sub"
+        in: "query"
+        description: |
+          OPTIONAL. The entity identifier of the subject for which you would like an entity statement issued. If this parameter is left out, it is considered to be the same as the issuer and would indicate a request for a self-issued statement.
+        required: false
+        schema:
+          type: string
+      - name: "aud"
+        in: "query"
+        description: OPTIONAL. If not present, MUST be treated as fetch.
+        required: false
+        schema:
+          type: string
+      - name: "is_leaf"
+        in: "query"
+        description: |
+          OPTIONAL. If left out, the result should include both leaf entities and intermediate nodes. If set to true, the response should contain only leaf entities. If set to false, the response should contain only intermediate nodes.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: SAML2 Metadata
+          content:
+            samlmetadata/xml:
+              schema:
+                type: object # definire lo schema SAML2 metadata
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+  /discovery/{protocol_type}:
+    get:
+      summary: Discovery
+      description: |
+        Ritorna la lista di oggetti SAML2 IdP o OIDC Provider
+      operationId: disco
+      tags:
+        - Discovery Service
+      parameters:
+      - name: "protocol_type"
+        in: "path"
+        description: "Lista degli attributi di tutte le entità per Protocollo"
+        required: true
+        schema:
+          type: string 
+          pattern: '^(saml2)|(oidc)$'
+      - name: "offset"
+        in: "query"
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 20
+        description: The number of items to skip before starting to collect the result set.
+      - name: "limit"
+        in: "query"
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 20
+        description: The numbers of items to return.
+      responses:
+        '200':
+          description: |
+            Lista di elementi da rappresentare all'interno della Discovery page (Button, select)
+          content:
+            application/json:
+              schema:
+                type: object
+                title: Discovery response
+                properties:
+                  entity_id:
+                    title: Entity ID
+                    type: string
+                  display_name:
+                    title: Display Name
+                    type: string
+                  display_logo:
+                    title: Display Logo
+                    type: string
+                    format: uri
+                  display_description:
+                    title: Display description
+                    type: string
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+  /status:
+    get:
+      summary: Ritorna lo stato del servizio di backend.
+      description: |
+        Se il backend è funzionante ritorna la data corrente
+      operationId: getStatus
+      tags:
+        - Stato
+      responses:
+        '200':
+          description: |
+            Il server di backend funziona correttamente
+          content:
+            application/json:
+              schema:
+                type: object
+                title: Risposta status
+                required:
+                  - status
+                properties:
+                  stati:
+                    title: Status
+                    type: object
+                    required:
+                      - status
+                    properties:
+                      stato:
+                        type: array
+                        items:
+                          properties:
+                            data:
+                              type: string
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '429':
+          $ref: '#/components/responses/429TooManyRequests'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '503':
+          $ref: '#/components/responses/503ServiceUnavailable'
+        default:
+          $ref: '#/components/responses/default'
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+components:
+  headers:
+    X-RateLimit-Limit:
+      $ref: 'https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/headers/X-RateLimit-Limit'
+    X-RateLimit-Remaining:
+      $ref: 'https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/headers/X-RateLimit-Remaining'
+    X-RateLimit-Reset:
+      $ref: 'https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/headers/X-RateLimit-Reset'
+    Retry-After:
+      $ref: 'https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/headers/Retry-After'
+  responses:
+    400BadRequest:
+      content:
+        application/json+problem:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Bad Request
+    401Unauthorized:
+      content:
+        application/json+problem:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Unauthorized
+    404NotFound:
+      content:
+        application/json+problem:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Not Found
+    429TooManyRequests:
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Too many requests
+    500InternalServerError:
+      content:
+        application/json+problem:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Internal Server Error
+    503ServiceUnavailable:
+      content:
+        application/json+problem:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Service Unavailable
+    default:
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+      description: Unexpected error
+  schemas:
+    Problem:
+      properties:
+        detail:
+          description: |
+            A human readable explanation specific to this occurrence of the
+            problem. You MUST NOT expose internal informations, personal
+            data or implementation details through this field.
+          example: Request took too long to complete.
+          type: string
+        instance:
+          description: |
+            An absolute URI that identifies the specific occurrence of the problem.
+            It may or may not yield further information if dereferenced.
+          format: uri
+          type: string
+        status:
+          description: |
+            The HTTP status code generated by the origin server for this occurrence
+            of the problem.
+          example: 503
+          exclusiveMaximum: true
+          format: int32
+          maximum: 600
+          minimum: 100
+          type: integer
+        title:
+          description: |
+            A short, summary of the problem type. Written in english and readable
+            for engineers (usually not suited for non technical stakeholders and
+            not localized); example: Service Unavailable
+          type: string
+        type:
+          default: 'about:blank'
+          description: |
+            An absolute URI that identifies the problem type.  When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          example: 'https://tools.ietf.org/html/rfc7231#section-6.6.4'
+          format: uri
+          type: string
+      type: object


### PR DESCRIPTION
The technologies and protocols currently used in digital identity federations are SAML2 and OIDC. In the future these protocols could be replaced by others, as a consequent technological and infrastructural evolution of the Federations of Digital Identities. For this reason, this document specifies a scheme that can be extended over time and based on Open API, conforming to the national interoperability model.

This scheme unifies draft-young-md-query (MDQ) and OIDC Federation 1.0 resources for the National Federation Authority role.

It wants to achieve the result of maintaining a backward compatibility with the pre-existing SAML2 entities and at the same time introducing the innovations of OIDC Federation 1.0.